### PR TITLE
Add `default_site_content` parameter to `octo_nginx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Puppet module for managing Nginx for Kraken Technologies machines.
 
 ## Changelog
 
+### v1.4
+- Add `default_site_content` parameter to `octo_nginx`, making it possible to use a template.
+
 ### v1.3
 - Stop logging `remote_user`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,7 @@
 class octo_nginx (
-    $default_site_source = undef,
+    # Only 1 of the following 2 parameters should be provided.
+    $default_site_source = undef,  # deprecated: use default_site_content with file() instead
+    $default_site_content = undef,
 ) {
     # Use custom PPA to get modern version of Nginx
     include apt
@@ -20,11 +22,12 @@ class octo_nginx (
         require => Package["nginx"],
     }
 
-    if $default_site_source {
+    if $default_site_source or $default_site_content {
         file { "nginx default site":
             path => "/etc/nginx/sites-enabled/default",
             ensure => "file",
             source => $default_site_source,
+            content => $default_site_content,
             require => Package["nginx"],
         }
         service { "nginx":


### PR DESCRIPTION
Makes it possible to use a template for the default site config. This is
useful if the config needs to vary depending on some higher-level
parameters.