### PR TITLE
Ensure $upstream_response_time is logged as a float, not a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Puppet module for managing Nginx for Kraken Technologies machines.
 
 ## Changelog
 
+### v1.4
+- Log `$upstream_response_time` as a float.
+
 ### v1.3
 - Stop logging `remote_user`
 

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -22,6 +22,13 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    # Map unset values in $upstream_response_time to `null` otherwise Nginx logs a "-" which creates
+    # invalid JSON in the log output.
+    map $upstream_response_time $uwsgi_response_time {
+        default $upstream_response_time;
+        "" null;
+    }
+
     # Log as JSON for better machine-readability
     log_format json escape=json '{ "time": "$time_iso8601", '
         '"remote_addr": "$remote_addr", '
@@ -31,7 +38,7 @@ http {
         '"status": "$status", '
         '"body_bytes_sent": $body_bytes_sent, '
         '"request_time": $request_time, '
-        '"upstream_response_time": "$upstream_response_time", '
+        '"upstream_response_time": $uwsgi_response_time, '
         '"http_referer": "$http_referer", '
         '"http_user_agent": "$http_user_agent" }';
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "octoenergy-octo_nginx",
-    "version": "1.3",
+    "version": "1.4",
     "author": "Kraken Technologies",
     "license": "BSD",
     "summary": "Nginx module for Kraken Technologies",


### PR DESCRIPTION
Prior to this change, we were logging it as a string to work-around a
problem where Nginx would log a "-" if there was no response.

See https://stackoverflow.com/questions/36788856/nginx-log-filter-upstream-response-time-json-elk-parsefailure