### PR TITLE
Increase nginx keepalive timeout to 410

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Puppet module for managing Nginx for Kraken Technologies machines.
 
 ## Changelog
 
+### v1.5
+- Increase keepalive timeout.
+
 ### v1.4
 - Log `$upstream_response_time` as a float.
 

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -15,7 +15,7 @@ http {
     # This needs to be higher than the idle timeout of the ELB server otherwise the ELB
     # will try and re-use the idle connection after Nginx has closed the connection resulting
     # in a 504 response.
-    keepalive_timeout 75;
+    keepalive_timeout 410;
     types_hash_max_size 2048;
     server_tokens off;
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "octoenergy-octo_nginx",
-    "version": "1.4",
+    "version": "1.5",
     "author": "Kraken Technologies",
     "license": "BSD",
     "summary": "Nginx module for Kraken Technologies",


### PR DESCRIPTION
The comment above the keepalive timeout suggests it should be greater than the load balancer idle timeout, which is currently set to 400, this PR increases keepalive timeout to marginally above to 410.

References:
- https://octoenergy.slack.com/archives/C01FM6D03PX/p1613049529468300
- https://github.com/octoenergy/octocloud/blob/master/terraform/modules/apiservice/load_balancers.tf#L19
