### PR TITLE
Remove pin on puppetlabs-apt module

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
     "dependencies": [
         {
             "name": "puppetlabs-apt",
-            "version_requirement": "2.2.1"
+            "version_requirement": ">= 2.2.1"
         }
     ]
 }


### PR DESCRIPTION
Change the puppetlabs-apt version requirement from `2.2.1`  to `>= 2.2.1`, as the datadog module requires apt > 4.x