### PR TITLE
Add Amazon Load Balancer trace ids to Nginx access logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Puppet module for managing Nginx for Kraken Technologies machines.
 
 ## Changelog
 
+### v1.8
+- Add Amazon Load Balancer Trace ID to access logs.
+
 ### v1.7
 - Update requirement on puppetlabs-apt dependency from "2.2.1" to ">= 2.2.1"
 

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -29,6 +29,11 @@ http {
         "" null;
     }
 
+    # Extract root trace ids (like Kraken does)
+    map $http_x_amzn_trace_id $root_trace_id {
+        ~Root=(?<t>[\w-]+) $t;
+    }
+
     # Log as JSON for better machine-readability
     log_format json escape=json '{ "time": "$time_iso8601", '
         '"remote_addr": "$remote_addr", '
@@ -40,6 +45,7 @@ http {
         '"request_time": $request_time, '
         '"upstream_response_time": $uwsgi_response_time, '
         '"http_referer": "$http_referer", '
+        '"meta": {"correlation_id": "$root_trace_id"}, '
         '"http_user_agent": "$http_user_agent" }';
 
     access_log /var/log/nginx/access.log json;

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "octoenergy-octo_nginx",
-    "version": "1.7",
+    "version": "1.8",
     "author": "Kraken Technologies",
     "license": "BSD",
     "summary": "Nginx module for Kraken Technologies",


### PR DESCRIPTION
This will allow us to see requests in Loggly throughout the web tier (Nginx + Django).

https://aws.amazon.com/premiumsupport/knowledge-center/trace-elb-x-amzn-trace-id/