### PR TITLE
Change nginx log directory owner to fix log rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Puppet module for managing Nginx for Kraken Technologies machines.
 
 ## Changelog
 
+### v1.9.2
+
+- Change nginx log directory owner to fix log rotation.
+
 ### v1.9.1
 
 - Fix bug in handling Ubuntu 20.04.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,14 @@ class octo_nginx (
         require => Exec["update package lists for nginx"],
     }
 
+    file { "nginx log dir":
+        path => "/var/log/nginx",
+        ensure => "directory",
+        owner => "www-data",
+        mode => "0755",
+        require => Package["nginx"],
+    }
+
     file { "nginx config":
         path => "/etc/nginx/nginx.conf",
         ensure => "file",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "octoenergy-octo_nginx",
-    "version": "1.9.1",
+    "version": "1.9.2",
     "author": "Kraken Technologies",
     "license": "BSD",
     "summary": "Nginx module for Kraken Technologies",


### PR DESCRIPTION
Prior to this change, `/var/log/nginx` was owned by `root`. This resulted in a broken log rotation where nginx worker processes would continue to write to a rotated file `access.log.1` with no further rotation until there's no disk space left. New log file `access.log.0` would remain empty.

Changing the owner user to `www-data` so that it correlates with nginx and logrotate config files resolves the issue. Usually instances don't last long enough for this to be a problem, however it's been observed on few `meter-points-service` instances.

Tested with Vagrant, got no errors related to the change:
`==> webhookserver: Notice: /Stage[main]/Octo_nginx/File[nginx log dir]/owner: owner changed 'root' to 'www-data'`

Tested on an api-server instance on oegb-test after CIS hardening cron job kicks in:

![Screenshot 2022-04-01 at 16 58 08](https://user-images.githubusercontent.com/60039710/161302001-41bc8fb4-5678-4128-a468-779d2d40a23f.png)

![Screenshot 2022-04-01 at 17 06 17](https://user-images.githubusercontent.com/60039710/161302023-77af6cad-123c-443c-97b5-0818d10d77cc.png)