### PR TITLE
Set open file limits in line with Nginx best practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Puppet module for managing Nginx for Kraken Technologies machines.
 
 ## Changelog
 
+### v1.11
+
+- Increase limits for number of open files to prevent running out during a DDoS.
+
 ### v1.10
 
 - Enable logging of `$remote_user` in logs

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -1,9 +1,19 @@
 user www-data;
-worker_processes 4;
+worker_processes auto;
 pid /run/nginx.pid;
 
+# https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#insufficient-fds
+# * LimitNOFILE (ulimit -n) must be more than worker_rlimit_nofile * worker_processes.
+# * "The common configuration mistake is not increasing the limit on FDs to at least twice
+#   the value of worker_connections"
+# 
+# The worker_processes is set to auto which ~= num CPUs, which on 2xlarge boxes is 8. This
+# requires 8192 FDs as we have set worker_rlimit_nofile to 1024. The nginx.service file
+# configures max FDs to 32768, which will be fine for machines with 32 CPUs.
+
+worker_rlimit_nofile 1024;
+
 events {
-    # Determine this number by running `ulimit -n`
     worker_connections 1024;
 }
 

--- a/files/nginx.service
+++ b/files/nginx.service
@@ -1,0 +1,30 @@
+# Stop dance for nginx
+# =======================
+#
+# ExecStop sends SIGQUIT (graceful stop) to the nginx process.
+# If, after 5s (--retry QUIT/5) nginx is still running, systemd takes control
+# and sends SIGTERM (fast shutdown) to the main process.
+# After another 5s (TimeoutStopSec=5), and if nginx is alive, systemd sends
+# SIGKILL to all the remaining processes in the process group (KillMode=mixed).
+#
+# nginx signals reference doc:
+# http://nginx.org/en/docs/control.html
+#
+[Unit]
+Description=A high performance web server and a reverse proxy server
+Documentation=man:nginx(8)
+After=network.target nss-lookup.target
+
+[Service]
+Type=forking
+PIDFile=/run/nginx.pid
+ExecStartPre=/usr/sbin/nginx -t -q -g 'daemon on; master_process on;'
+ExecStart=/usr/sbin/nginx -g 'daemon on; master_process on;'
+ExecReload=/usr/sbin/nginx -g 'daemon on; master_process on;' -s reload
+ExecStop=-/sbin/start-stop-daemon --quiet --stop --retry QUIT/5 --pidfile /run/nginx.pid
+TimeoutStopSec=5
+KillMode=mixed
+LimitNOFILE=32768
+
+[Install]
+WantedBy=multi-user.target

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,13 @@ class octo_nginx (
         require => Package["nginx"],
     }
 
+    file { "nginx systemd config":
+        path => "/etc/systemd/system/multi-user.target.wants/nginx.service",
+        ensure => "file",
+        source => "puppet:///modules/octo_nginx/nginx.service",
+        require => Package["nginx"],
+    }
+
     if $default_site_source {
         file { "nginx default site":
             path => "/etc/nginx/sites-enabled/default",


### PR DESCRIPTION
Prior to this change, we would run out of file descriptors because Nginx was configured for 4 workers with 1024 files each, but the default number of open files allowed by the systemd unit file (not set) is 1024, so we could run out of file descriptors when under a DDoS.

This change sets a number of values:
 * worker_processes auto - this allows nginx to use a process per CPU
 * worker_rlimit_nofile 1024 - limit each nginx process to 1024 FDs
 * LimitNOFILE=32768 - systemd unit file sets a larger FD limit

This gives us enough open files for up to 32 processes. Since our worker machines are much smaller than this, we should never run out of file descriptors.