### PR TITLE
Stop logging request user in Nginx logs

### DIFF
--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -48,7 +48,6 @@ http {
     log_format json escape=json '{ "time": "$time_iso8601", '
         '"remote_addr": "$remote_addr", '
         '"host": "$host", '
-        '"user": "$remote_user", '
         '"request": "$request_uri", '
         '"method": "$request_method", '
         '"status": "$status", '


### PR DESCRIPTION
As the content within this header isn't always appropriate for logging.