### PR TITLE
Add forwarded for header

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Puppet module for managing Nginx for Kraken Technologies machines.
 
 ## Changelog
 
+### v1.15
+
+- Start logging `$http_x_forwarded_for` 
+
 ### v1.14
 
 - Stop logging `$remote_user` in logs by default

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -56,7 +56,8 @@ http {
         '"upstream_response_time": $uwsgi_response_time, '
         '"http_referer": "$http_referer", '
         '"meta": {"correlation_id": "$root_trace_id"}, '
-        '"http_user_agent": "$http_user_agent" }';
+        '"http_user_agent": "$http_user_agent",'
+        '"http_x_forwarded_for": "$http_x_forwarded_for" }';
 
     access_log /var/log/nginx/access.log json;
     error_log /var/log/nginx/error.log;

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "octoenergy-octo_nginx",
-  "version": "1.14",
+  "version": "1.15",
   "author": "Kraken Technologies",
   "license": "BSD",
   "summary": "Nginx module for Kraken Technologies",


### PR DESCRIPTION
Adding `http_x_forwarded_for` to Nginx logs (and therefore DataDog logs).

https://octoenergy.slack.com/archives/C05PM7WB0JV/p1692838850995679?thread_ts=1692837744.951729&cid=C05PM7WB0JV
https://app.asana.com/0/1200048314604488/1205341063097161/f